### PR TITLE
Manage parameters

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,8 @@ a `.beton` dataset from a `torch` dataset.
 Example from the `dataset_creation.py` script:
 
 ```
+from ffcv.fields import RGBImageField
+
 from ffcv_pl.generate_dataset import create_beton_wrapper
 from torch.utils.data.dataset import Dataset
 import numpy as np
@@ -97,18 +99,23 @@ class ToyImageLabelDataset(Dataset):
 
 
 def main():
-    
+
     # 1. Instantiate the torch dataset that you want to create
     # Important: the __get_item__ dataset must return tuples! (This depends on FFCV library)
     image_label_dataset = ToyImageLabelDataset(n_samples=256)
-
-    # 2. call the method, and it will automatically create the .beton dataset for you.
-    create_beton_wrapper(image_label_dataset, "./data/image_label.beton")
-
     
+    # 2. Optional: create Field objects.
+    # here overwrites only RGBImageField, leave default IntField.
+    fields = (RGBImageField(write_mode='jpg', max_resolution=32), None)
+    
+    # 3. call the method, and it will automatically create the .beton dataset for you.
+    create_beton_wrapper(image_label_dataset, "./data/image_label.beton", fields)
+
+
 if __name__ == '__main__':
-    
+
     main()
+
 ```
 
 ## Dataloader and Datamodule

--- a/src/dataset_creation.py
+++ b/src/dataset_creation.py
@@ -1,3 +1,5 @@
+from ffcv.fields import RGBImageField
+
 from ffcv_pl.generate_dataset import create_beton_wrapper
 from torch.utils.data.dataset import Dataset
 import numpy as np
@@ -23,8 +25,12 @@ def main():
     # Important: the __get_item__ dataset must return tuples! (This depends on FFCV library)
     image_label_dataset = ToyImageLabelDataset(n_samples=256)
 
-    # 2. call the method, and it will automatically create the .beton dataset for you.
-    create_beton_wrapper(image_label_dataset, "./data/image_label.beton")
+    # 2. Optional: create Field objects.
+    # here overwrites only RGBImageField, leave default IntField.
+    fields = (RGBImageField(write_mode='jpg', max_resolution=32), None)
+
+    # 3. call the method, and it will automatically create the .beton dataset for you.
+    create_beton_wrapper(image_label_dataset, "./data/image_label.beton", fields)
 
 
 if __name__ == '__main__':

--- a/src/ffcv_pl/data_loading.py
+++ b/src/ffcv_pl/data_loading.py
@@ -7,7 +7,7 @@ class FFCVDataModule(pl.LightningDataModule):
 
     def __init__(self, batch_size: int, num_workers: int, is_dist: bool, train_manager: FFCVPipelineManager = None,
                  val_manager: FFCVPipelineManager = None, test_manager: FFCVPipelineManager = None,
-                 predict_manager: FFCVPipelineManager = None, os_cache: bool = True, seed: int = None,
+                 predict_manager: FFCVPipelineManager = None, os_cache: bool = True, seed: int = None, **kwargs
                  ) -> None:
         """
         Define PL DataModule (https://lightning.ai/docs/pytorch/stable/data/datamodule.html) object using
@@ -22,6 +22,9 @@ class FFCVDataModule(pl.LightningDataModule):
         :param os_cache: option for the ffcv loader, depending on your dataset.
                         Read official docs: https://docs.ffcv.io/parameter_tuning.html
         :param seed: fix data loading process to ensure reproducibility
+        :param kwargs: pass any extra argument of the FFCV Loader object using the format "type_pname", where type is
+        one of {train, val, test, predict} and type is one of {indices, custom_fields, drop_last, batches_ahead,
+        recompile}. Check out https://docs.ffcv.io/making_dataloaders.html for more information about the parameters.
         """
 
         # initial condition must be satisfied
@@ -36,6 +39,8 @@ class FFCVDataModule(pl.LightningDataModule):
         self.os_cache = os_cache
 
         self.is_dist = is_dist
+
+        self.kwargs = kwargs
 
         self.train_manager = train_manager
         self.val_manager = val_manager
@@ -62,7 +67,15 @@ class FFCVDataModule(pl.LightningDataModule):
                           order=self.train_manager.ordering,
                           pipelines=self.train_manager.pipeline,
                           distributed=self.is_dist,
-                          seed=self.seed)
+                          seed=self.seed,
+                          indices=self.kwargs['train_indices'] if 'train_indices' in self.kwargs.keys() else None,
+                          custom_fields=self.kwargs['train_custom_fields'] if
+                          'train_custom_fields' in self.kwargs.keys() else {},
+                          drop_last=self.kwargs['train_drop_last'] if 'train_drop_last' in self.kwargs.keys() else True,
+                          batches_ahead=self.kwargs['train_batches_ahead'] if
+                          'train_batches_ahead' in self.kwargs.keys() else 3,
+                          recompile=self.kwargs['train_recompile'] if
+                          'train_recompile' in self.kwargs.keys() else False)
 
     def val_dataloader(self):
         if self.val_manager is not None:
@@ -73,7 +86,14 @@ class FFCVDataModule(pl.LightningDataModule):
                           order=self.val_manager.ordering,
                           pipelines=self.val_manager.pipeline,
                           distributed=self.is_dist,
-                          seed=self.seed)
+                          seed=self.seed,
+                          indices=self.kwargs['val_indices'] if 'val_indices' in self.kwargs.keys() else None,
+                          custom_fields=self.kwargs['val_custom_fields'] if
+                          'val_custom_fields' in self.kwargs.keys() else {},
+                          drop_last=self.kwargs['val_drop_last'] if 'val_drop_last' in self.kwargs.keys() else True,
+                          batches_ahead=self.kwargs['val_batches_ahead'] if
+                          'val_batches_ahead' in self.kwargs.keys() else 3,
+                          recompile=self.kwargs['val_recompile'] if 'val_recompile' in self.kwargs.keys() else False)
 
     def test_dataloader(self):
         if self.test_manager is not None:
@@ -84,7 +104,14 @@ class FFCVDataModule(pl.LightningDataModule):
                           order=self.test_manager.ordering,
                           pipelines=self.test_manager.pipeline,
                           distributed=self.is_dist,
-                          seed=self.seed)
+                          seed=self.seed,
+                          indices=self.kwargs['test_indices'] if 'test_indices' in self.kwargs.keys() else None,
+                          custom_fields=self.kwargs['test_custom_fields'] if
+                          'test_custom_fields' in self.kwargs.keys() else {},
+                          drop_last=self.kwargs['test_drop_last'] if 'test_drop_last' in self.kwargs.keys() else True,
+                          batches_ahead=self.kwargs['test_batches_ahead'] if
+                          'test_batches_ahead' in self.kwargs.keys() else 3,
+                          recompile=self.kwargs['test_recompile'] if 'test_recompile' in self.kwargs.keys() else False)
 
     def predict_dataloader(self):
         if self.predict_manager is not None:
@@ -95,4 +122,13 @@ class FFCVDataModule(pl.LightningDataModule):
                           order=self.predict_manager.ordering,
                           pipelines=self.predict_manager.pipeline,
                           distributed=self.is_dist,
-                          seed=self.seed)
+                          seed=self.seed,
+                          indices=self.kwargs['predict_indices'] if 'predict_indices' in self.kwargs.keys() else None,
+                          custom_fields=self.kwargs['predict_custom_fields'] if
+                          'predict_custom_fields' in self.kwargs.keys() else {},
+                          drop_last=self.kwargs['predict_drop_last'] if
+                          'predict_drop_last' in self.kwargs.keys() else True,
+                          batches_ahead=self.kwargs['predict_batches_ahead'] if
+                          'predict_batches_ahead' in self.kwargs.keys() else 3,
+                          recompile=self.kwargs['predict_recompile'] if
+                          'predict_recompile' in self.kwargs.keys() else False)

--- a/src/ffcv_pl/ffcv_utils/utils.py
+++ b/src/ffcv_pl/ffcv_utils/utils.py
@@ -24,7 +24,7 @@ def field_to_str(f: Field) -> str:
 def obj_to_field(obj: Any) -> Field:
 
     if isinstance(obj, Image):
-        return RGBImageField()
+        return RGBImageField(write_mode="jpg")
 
     elif isinstance(obj, int):
         return IntField()

--- a/src/ffcv_pl/generate_dataset.py
+++ b/src/ffcv_pl/generate_dataset.py
@@ -5,26 +5,53 @@ import os
 from ffcv_pl.ffcv_utils.utils import field_to_str, obj_to_field
 
 
-def create_beton_wrapper(torch_dataset: Dataset, output_path: str) -> None:
+def create_beton_wrapper(torch_dataset: Dataset, output_path: str, fields: tuple | None = None,
+                         page_size: int | None = None, num_workers: int = -1,
+                         indices: list[int] | None = None, chunksize: int = 100, shuffle_indices: bool = False,
+                         ) -> None:
     """
-    :param torch_dataset: Pytorch Dataset object (https://pytorch.org/tutorials/beginner/basics/data_tutorial.html).
+    Simple utility function that allows the creation of .beton files from Torch Datasets.
+    References: https://docs.ffcv.io/writing_datasets.html
 
     The dataset can have any number/type of parameters in the __init__ method.
 
     Constraints on the __get_item__ method:
         According to the official ffcv docs, the dataset must return a tuple object of any length.
-        See for example: https://docs.ffcv.io/writing_datasets.html
 
-        The type of the elements inside the tuple is restricted to the ffcv.fields admitted types:
+        The type of the elements inside the tuple is automatically mapped to the ffcv.fields admitted types:
         https://docs.ffcv.io/api/fields.html
 
-        (PIL Images - RGBImageField, integers for IntField, floats for FloatField, numpy arrays for NDArrayField,
-        dicts for JSONField, torch tensors for TorchTensorField and
-        1D uint8 numpy array of variable length for BytesField)
+    Default Fields (depending on objects obtained from Dataset.__get_item__):
 
+    PIL Images - RGBImageField(writemode='jpg')
+
+    Integers - IntField()
+
+    Floats - FloatField()
+
+    Numpy arrays - NDArrayField(obj.dtype, obj.shape)
+
+    Dict - JSONField()
+
+    Torch tensor - TorchTensorField(obj.dtype, obj.shape)
+
+    1D uint8 numpy array - BytesField()
+
+    :param torch_dataset: Pytorch Dataset object (https://pytorch.org/tutorials/beginner/basics/data_tutorial.html).
     :param output_path: desired path for .beton output file, "/" separated. E.g. "./my_dataset.beton"
-
+    :param fields: use this if you want to use Fields different from default.
+                   The length and order must respect the "get_item" return of the torch Dataset.
+                   If you want to overwrite only some fields, pass None to the remaining positions.
+    :param page_size: page size internally used. (optional argument of DatasetWriter object)
+    :param num_workers: Number of processes to use. (optional argument of DatasetWriter object)
+    :param indices: Use a subset of the dataset specified by indices. (optional argument of from_indexed_dataset method)
+    :param chunksize: Size of chunks processed by each worker during conversion.
+                      (optional argument of from_indexed_dataset method)
+    :param shuffle_indices: Shuffle order of the dataset. (optional argument of from_indexed_dataset method)
     """
+
+    # get default page size (4 * MIN_PAGE_SIZE): --> https://github.com/libffcv/ffcv/blob/main/ffcv/writer.py
+    page_size = 4 * (2 ** 21) if page_size is None else page_size
 
     # 1. format output path
     assert len(output_path) > 0, 'param: output_path cannot be an empty string'
@@ -45,22 +72,30 @@ def create_beton_wrapper(torch_dataset: Dataset, output_path: str) -> None:
         raise AttributeError("According to the official ffcv docs, the dataset must return a tuple object. "
                              "See for example: https://docs.ffcv.io/writing_datasets.html")
 
-    fields = []
-    for obj in tuple_obj:
-        fields.append(obj_to_field(obj))
+    if fields is None:
+        fields = tuple([None for _ in range(len(tuple_obj))])
+
+    if not len(fields) == len(tuple_obj):
+        raise AttributeError("Passed a wrong number of 'fields' objects.\n"
+                             f"The __get_item__ method of the specified dataset returns {len(tuple_obj)} elements, but"
+                             f" {len(fields)} objects were passed.")
+
+    final_fields = []
+    for obj, f in zip(tuple_obj, fields):
+        final_fields.append(obj_to_field(obj) if f is None else f)
 
     # 2. create dict of fields
     final_mapping = {}
-    for i, f in enumerate(fields):
+    for i, f in enumerate(final_fields):
         final_mapping[f'{field_to_str(type(f))}_{i}'] = f
 
     # official guidelines: https://docs.ffcv.io/writing_datasets.html
     print(f'[INFO] creating ffcv dataset into file: {output_path}')
     print(f'[INFO] number of items: {len(torch_dataset)}')
-    print(f'[INFO] ffcv fields of items: {fields}')
+    print(f'[INFO] ffcv fields of items: {final_fields}')
 
-    writer = DatasetWriter(output_path, final_mapping)
-    writer.from_indexed_dataset(torch_dataset)
+    writer = DatasetWriter(output_path, final_mapping, page_size=page_size, num_workers=num_workers)
+    writer.from_indexed_dataset(torch_dataset, indices=indices, chunksize=chunksize, shuffle_indices=shuffle_indices)
 
     print(f'[INFO] Done.')
     print(f'#' * 30)

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,11 +1,16 @@
 from setuptools import setup
 
+long_description = """
+                   Version Updates: allow optional arguments for FFCVDataModule and create_beton_wrapper.\n
+                   For example usages/installation, 
+                   check [github project](https://github.com/SerezD/ffcv_pytorch_lightning)
+                   """
 
 setup(name='ffcv_pl',
-      version='0.3.1',
+      version='0.3.2',
       packages=['ffcv_pl', 'ffcv_pl.ffcv_utils'],
       description='manage fast data loading with ffcv and pytorch lightning',
-      long_description='see [github project](https://github.com/SerezD/ffcv_pytorch_lightning) ',
+      long_description=long_description,
       long_description_content_type='text/markdown',
       url='https://github.com/SerezD/ffcv_pytorch_lightning',
       author='DSerez',


### PR DESCRIPTION
Introduces some optional parameters to the `create_beton_wrapper` method and `FFCVDataModule` object. 

The changes are still compatible with the 0.3.1 version. 

It is now possible to pass custom Fields when creating a dataset and other parameters of the DatasetWriter object. 

Also, all parameters if the FFCV.Loader object are now accessible.